### PR TITLE
記事CRUD API実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## 概要
 ITエンジニアが技術記事を投稿し、有料コンテンツとして販売できるプラットフォームです。
 
-## 実装状況（Laravel基盤フェーズ完了）
+## 実装状況（記事CRUD APIフェーズ完了）
 
 ### ✅ 完了機能
 - **Docker環境構築**: フロントエンド、バックエンド、データベースのコンテナ化
@@ -12,13 +12,14 @@ ITエンジニアが技術記事を投稿し、有料コンテンツとして販
 - **データベース設計**: 7テーブル完全構築（users, articles, tags, article_tags, payments, comments, payouts）
 - **認証システム**: Laravel Sanctum実装、トークンベース認証API完成
 - **API基盤**: 認証関連エンドポイント（登録・ログイン・ログアウト・ユーザー情報取得）
-- **開発環境**: ESLint + Prettier設定、Laravel Pint対応、テスト環境整備
+- **記事CRUD API**: 記事の作成・読取・更新・削除の完全実装、権限制御、バリデーション
+- **開発環境**: ESLint + Prettier設定、Laravel Pint対応、テスト環境整備、TDD実践
 
 ### 🚧 次期実装予定（MVP機能開発）
-- 記事CRUD API（作成・読取・更新・削除）
 - タグ管理API（記事へのタグ付け機能）
 - フロントエンド認証画面（ログイン・登録）
 - 記事一覧・詳細画面
+- 記事投稿・編集画面
 - ダークモード実装
 
 ## 技術スタック
@@ -132,6 +133,55 @@ Authorization: Bearer {token}
 #### ユーザー情報取得（認証必要）
 ```bash
 GET /api/user
+Authorization: Bearer {token}
+```
+
+### 記事API
+
+#### 記事一覧取得
+```bash
+GET /api/articles
+```
+
+#### 記事詳細取得
+```bash
+GET /api/articles/{id}
+```
+
+#### 記事作成（認証必要）
+```bash
+POST /api/articles
+Authorization: Bearer {token}
+Content-Type: application/json
+
+{
+    "title": "記事タイトル",
+    "content": "記事本文",
+    "thumbnail_url": "https://example.com/image.jpg",
+    "status": "draft",
+    "is_paid": false,
+    "price": 1000,
+    "preview_content": "プレビュー内容",
+    "is_featured": false
+}
+```
+
+#### 記事更新（認証必要・作成者のみ）
+```bash
+PUT /api/articles/{id}
+Authorization: Bearer {token}
+Content-Type: application/json
+
+{
+    "title": "更新後タイトル",
+    "content": "更新後本文",
+    "status": "published"
+}
+```
+
+#### 記事削除（認証必要・作成者のみ）
+```bash
+DELETE /api/articles/{id}
 Authorization: Bearer {token}
 ```
 

--- a/backend/app/Http/Controllers/API/ArticleController.php
+++ b/backend/app/Http/Controllers/API/ArticleController.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Http\Controllers\Controller;
+use App\Models\Article;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class ArticleController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        $articles = Article::with('user')->latest()->get();
+
+        return response()->json([
+            'data' => $articles,
+        ]);
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        $request->validate([
+            'title' => 'required|string|max:255',
+            'content' => 'required|string',
+            'thumbnail_url' => 'nullable|url',
+            'status' => 'in:draft,published',
+            'is_paid' => 'boolean',
+            'price' => 'nullable|numeric|min:0',
+            'preview_content' => 'nullable|string',
+            'is_featured' => 'boolean',
+        ]);
+
+        $article = Article::create([
+            'user_id' => Auth::id(),
+            'title' => $request->title,
+            'content' => $request->content,
+            'thumbnail_url' => $request->thumbnail_url,
+            'status' => $request->status ?? 'draft',
+            'is_paid' => $request->is_paid ?? false,
+            'price' => $request->price,
+            'preview_content' => $request->preview_content,
+            'is_featured' => $request->is_featured ?? false,
+        ]);
+
+        return response()->json([
+            'data' => $article->load('user'),
+        ], 201);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(Article $article)
+    {
+        return response()->json([
+            'data' => $article->load('user', 'tags'),
+        ]);
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, Article $article)
+    {
+        if ($article->user_id !== Auth::id()) {
+            return response()->json([
+                'message' => 'Forbidden',
+            ], 403);
+        }
+
+        $request->validate([
+            'title' => 'sometimes|required|string|max:255',
+            'content' => 'sometimes|required|string',
+            'thumbnail_url' => 'nullable|url',
+            'status' => 'in:draft,published',
+            'is_paid' => 'boolean',
+            'price' => 'nullable|numeric|min:0',
+            'preview_content' => 'nullable|string',
+            'is_featured' => 'boolean',
+        ]);
+
+        $article->update($request->only([
+            'title',
+            'content',
+            'thumbnail_url',
+            'status',
+            'is_paid',
+            'price',
+            'preview_content',
+            'is_featured',
+        ]));
+
+        return response()->json([
+            'data' => $article->load('user'),
+        ]);
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Article $article)
+    {
+        if ($article->user_id !== Auth::id()) {
+            return response()->json([
+                'message' => 'Forbidden',
+            ], 403);
+        }
+
+        $article->delete();
+
+        return response()->json(null, 204);
+    }
+}

--- a/backend/app/Models/Article.php
+++ b/backend/app/Models/Article.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class Article extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'title',
+        'content',
+        'thumbnail_url',
+        'status',
+        'is_paid',
+        'price',
+        'preview_content',
+        'is_featured',
+    ];
+
+    protected $casts = [
+        'is_paid' => 'boolean',
+        'is_featured' => 'boolean',
+        'price' => 'decimal:2',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function tags(): BelongsToMany
+    {
+        return $this->belongsToMany(Tag::class, 'article_tags');
+    }
+}

--- a/backend/app/Models/Tag.php
+++ b/backend/app/Models/Tag.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class Tag extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'slug',
+    ];
+
+    public function articles(): BelongsToMany
+    {
+        return $this->belongsToMany(Article::class, 'article_tags');
+    }
+}

--- a/backend/database/factories/ArticleFactory.php
+++ b/backend/database/factories/ArticleFactory.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Article>
+ */
+class ArticleFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'title' => fake()->sentence(4),
+            'content' => fake()->paragraphs(3, true),
+            'thumbnail_url' => fake()->imageUrl(640, 480, 'business'),
+            'status' => fake()->randomElement(['draft', 'published']),
+            'is_paid' => fake()->boolean(30),
+            'price' => fake()->optional(0.7)->randomFloat(2, 100, 10000),
+            'preview_content' => fake()->paragraph(),
+            'is_featured' => fake()->boolean(10),
+        ];
+    }
+
+    public function published(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => 'published',
+        ]);
+    }
+
+    public function draft(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => 'draft',
+        ]);
+    }
+
+    public function paid(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'is_paid' => true,
+            'price' => fake()->randomFloat(2, 500, 5000),
+        ]);
+    }
+
+    public function free(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'is_paid' => false,
+            'price' => null,
+        ]);
+    }
+}

--- a/backend/database/factories/UserFactory.php
+++ b/backend/database/factories/UserFactory.php
@@ -25,10 +25,12 @@ class UserFactory extends Factory
     {
         return [
             'name' => fake()->name(),
+            'username' => fake()->unique()->userName(),
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
+            'role' => 'author',
         ];
     }
 

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\API\ArticleController;
 use App\Http\Controllers\API\AuthController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
@@ -7,6 +8,17 @@ use Illuminate\Support\Facades\Route;
 // 認証不要のルート
 Route::post('/register', [AuthController::class, 'register']);
 Route::post('/login', [AuthController::class, 'login']);
+
+// 記事関連のルート（認証不要：一覧・詳細）
+Route::get('articles', [ArticleController::class, 'index']);
+Route::get('articles/{article}', [ArticleController::class, 'show']);
+
+// 記事関連のルート（認証必要：作成・更新・削除）
+Route::middleware('auth:sanctum')->group(function () {
+    Route::post('articles', [ArticleController::class, 'store']);
+    Route::put('articles/{article}', [ArticleController::class, 'update']);
+    Route::delete('articles/{article}', [ArticleController::class, 'destroy']);
+});
 
 // 認証が必要なルート
 Route::middleware('auth:sanctum')->group(function () {

--- a/backend/tests/Feature/ArticleCrudTest.php
+++ b/backend/tests/Feature/ArticleCrudTest.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Article;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class ArticleCrudTest extends TestCase
+{
+    use RefreshDatabase, WithFaker;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create([
+            'role' => 'author',
+        ]);
+    }
+
+    public function test_authenticated_user_can_create_article(): void
+    {
+        Sanctum::actingAs($this->user);
+
+        $articleData = [
+            'title' => 'Test Article',
+            'content' => 'This is test content.',
+            'status' => 'draft',
+            'is_paid' => false,
+        ];
+
+        $response = $this->postJson('/api/articles', $articleData);
+
+        $response->assertStatus(201)
+            ->assertJsonStructure([
+                'data' => [
+                    'id',
+                    'title',
+                    'content',
+                    'status',
+                    'is_paid',
+                    'user_id',
+                    'created_at',
+                    'updated_at',
+                ],
+            ]);
+
+        $this->assertDatabaseHas('articles', [
+            'title' => 'Test Article',
+            'user_id' => $this->user->id,
+        ]);
+    }
+
+    public function test_unauthenticated_user_cannot_create_article(): void
+    {
+        $articleData = [
+            'title' => 'Test Article',
+            'content' => 'This is test content.',
+        ];
+
+        $response = $this->postJson('/api/articles', $articleData);
+
+        $response->assertStatus(401);
+    }
+
+    public function test_can_get_articles_list(): void
+    {
+        Article::factory()->count(5)->create(['user_id' => $this->user->id]);
+
+        $response = $this->getJson('/api/articles');
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'data' => [
+                    '*' => [
+                        'id',
+                        'title',
+                        'content',
+                        'status',
+                        'user_id',
+                        'created_at',
+                        'updated_at',
+                    ],
+                ],
+            ]);
+    }
+
+    public function test_can_get_single_article(): void
+    {
+        $article = Article::factory()->create(['user_id' => $this->user->id]);
+
+        $response = $this->getJson("/api/articles/{$article->id}");
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'data' => [
+                    'id',
+                    'title',
+                    'content',
+                    'status',
+                    'user_id',
+                    'created_at',
+                    'updated_at',
+                ],
+            ]);
+    }
+
+    public function test_authenticated_user_can_update_own_article(): void
+    {
+        Sanctum::actingAs($this->user);
+
+        $article = Article::factory()->create(['user_id' => $this->user->id]);
+
+        $updateData = [
+            'title' => 'Updated Title',
+            'content' => 'Updated content.',
+            'status' => 'published',
+        ];
+
+        $response = $this->putJson("/api/articles/{$article->id}", $updateData);
+
+        $response->assertStatus(200);
+
+        $this->assertDatabaseHas('articles', [
+            'id' => $article->id,
+            'title' => 'Updated Title',
+            'status' => 'published',
+        ]);
+    }
+
+    public function test_user_cannot_update_another_users_article(): void
+    {
+        Sanctum::actingAs($this->user);
+
+        $otherUser = User::factory()->create();
+        $article = Article::factory()->create(['user_id' => $otherUser->id]);
+
+        $updateData = [
+            'title' => 'Updated Title',
+        ];
+
+        $response = $this->putJson("/api/articles/{$article->id}", $updateData);
+
+        $response->assertStatus(403);
+    }
+
+    public function test_authenticated_user_can_delete_own_article(): void
+    {
+        Sanctum::actingAs($this->user);
+
+        $article = Article::factory()->create(['user_id' => $this->user->id]);
+
+        $response = $this->deleteJson("/api/articles/{$article->id}");
+
+        $response->assertStatus(204);
+
+        $this->assertDatabaseMissing('articles', [
+            'id' => $article->id,
+        ]);
+    }
+
+    public function test_user_cannot_delete_another_users_article(): void
+    {
+        Sanctum::actingAs($this->user);
+
+        $otherUser = User::factory()->create();
+        $article = Article::factory()->create(['user_id' => $otherUser->id]);
+
+        $response = $this->deleteJson("/api/articles/{$article->id}");
+
+        $response->assertStatus(403);
+    }
+
+    public function test_article_creation_validation(): void
+    {
+        Sanctum::actingAs($this->user);
+
+        $response = $this->postJson('/api/articles', []);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['title', 'content']);
+    }
+}


### PR DESCRIPTION
## Summary
記事の完全なCRUD (Create, Read, Update, Delete) 機能をAPIとして実装しました。

- ✅ **記事作成API**: 認証ユーザーが新規記事を投稿
- ✅ **記事一覧API**: 全ユーザーが記事一覧を取得
- ✅ **記事詳細API**: 全ユーザーが記事詳細を取得
- ✅ **記事更新API**: 作成者のみ自分の記事を更新
- ✅ **記事削除API**: 作成者のみ自分の記事を削除

## Technical Details
- **権限制御**: Laravel Sanctumによる認証・認可
- **バリデーション**: 入力値の厳格な検証
- **TDD実践**: 9つのテストケースによる品質保証
- **コード品質**: Laravel Pint による自動整形

## Test Coverage
- 認証ユーザーによる記事作成
- 未認証ユーザーのアクセス制御
- 記事一覧・詳細取得
- 作成者のみの更新・削除権限
- バリデーションエラーハンドリング

## Test plan
- [ ] 記事作成APIの動作確認
- [ ] 記事一覧・詳細取得の動作確認
- [ ] 権限制御の動作確認（他ユーザーの記事は編集不可）
- [ ] バリデーションの動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)