### PR TITLE
fix: マイページアバター表示問題の修正と購入履歴改善

### DIFF
--- a/frontend/src/components/UserProfileView.tsx
+++ b/frontend/src/components/UserProfileView.tsx
@@ -415,7 +415,7 @@ const UserProfileView: React.FC<UserProfileViewProps> = ({
                   </div>
                 ) : (
                   <AvatarUpload
-                    currentAvatar={user?.avatar_path}
+                    currentAvatar={user?.avatar_url}
                     onUpload={handleAvatarUpload}
                     onDelete={handleAvatarDelete}
                     loading={avatarUploading}
@@ -812,7 +812,7 @@ const UserProfileView: React.FC<UserProfileViewProps> = ({
                               purchase.status,
                             )}
                           >
-                            {purchase.status === "success"
+                            {purchase.status === "completed"
                               ? "完了"
                               : purchase.status === "failed"
                                 ? "失敗"
@@ -820,6 +820,29 @@ const UserProfileView: React.FC<UserProfileViewProps> = ({
                           </span>
                         </div>
                       </div>
+                      {purchase.status === "completed" && purchase.article_id && (
+                        <Button
+                          variant="primary"
+                          size="md"
+                          className="flex items-center justify-center gap-2 mt-2"
+                          onClick={() => navigate(`/articles/${purchase.article_id}`)}
+                        >
+                          <svg
+                            className="w-4 h-4"
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={2}
+                              d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.746 0 3.332.477 4.5 1.253v13C19.832 18.477 18.246 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
+                            />
+                          </svg>
+                          記事を読む
+                        </Button>
+                      )}
                     </div>
                   </div>
                 ))}


### PR DESCRIPTION
## Summary
- マイページでアバターが表示されていない問題を修正
- 購入履歴での決済ステータス表示を統一
- マイページ購入履歴タブに記事ナビゲーション機能を追加

## 主な変更内容
### アバター表示の修正
- `UserProfileView.tsx`: AvatarUploadコンポーネントに渡すプロパティを `avatar_path` から `avatar_url` に修正
- Laravelの動的アクセサーで生成される正しいBASE64画像データを使用するように修正

### 購入履歴の改善
- 決済ステータスの表示を "success" から "completed" に統一
- マイページ購入履歴タブに「記事を読む」ボタンを追加
- 完了済み購入に対してのみ記事へのナビゲーションを表示

## 問題の根本原因
- AvatarUploadコンポーネントは `avatar_url`（サーバー側で生成されたBASE64データ）を期待
- しかし、UserProfileViewでは間違って `avatar_path`（古い形式のパス文字列）を渡していた
- この不一致により、アバター画像が表示されていなかった

## Test plan
- [x] ESLintチェック実行（エラーなし）
- [x] フロントエンドアクセス確認（正常）
- [x] アバター表示の修正確認
- [x] 購入履歴ナビゲーション機能の追加確認
- [x] 決済ステータス統一の確認

🤖 Generated with [Claude Code](https://claude.ai/code)