### PR TITLE
fix: マイページのアバター関連不具合修正

### DIFF
--- a/frontend/src/components/AdminProfileView.tsx
+++ b/frontend/src/components/AdminProfileView.tsx
@@ -289,7 +289,7 @@ const AdminProfileView: React.FC<AdminProfileViewProps> = ({
             <CardBody>
               <div className="text-center">
                 <AvatarUpload
-                  currentAvatar={user?.avatar_path}
+                  currentAvatar={user?.avatar_url}
                   onUpload={handleAvatarUpload}
                   onDelete={handleAvatarDelete}
                   loading={avatarUploading}

--- a/frontend/src/components/UserProfileModal.tsx
+++ b/frontend/src/components/UserProfileModal.tsx
@@ -258,9 +258,9 @@ const UserProfileModal: React.FC<UserProfileModalProps> = ({
                         </h3>
                         {isReadOnly ? (
                           <div className="flex justify-center">
-                            {user.avatar_path ? (
+                            {user.avatar_url ? (
                               <img
-                                src={`http://localhost:8000${user.avatar_path}`}
+                                src={user.avatar_url}
                                 alt={user.name}
                                 className="h-32 w-32 rounded-full object-cover"
                               />
@@ -278,7 +278,7 @@ const UserProfileModal: React.FC<UserProfileModalProps> = ({
                           </div>
                         ) : (
                           <AvatarUpload
-                            currentAvatar={user.avatar_path}
+                            currentAvatar={user.avatar_url}
                             onUpload={() => {}}
                             onDelete={() => {}}
                             loading={avatarUploading}

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -110,7 +110,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         const currentUser = await AuthService.getCurrentUser();
         console.log("✅ AuthContext.refreshUser: Got user", {
           username: currentUser.username,
-          hasAvatar: !!currentUser.avatar_path,
+          hasAvatar: !!currentUser.avatar_url,
         });
         setUser(currentUser);
         console.log("✅ AuthContext.refreshUser: User updated in context");
@@ -152,7 +152,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const updateUser = (newUser: User): void => {
     console.log("🔵 AuthContext.updateUser: Updating user directly", {
       username: newUser.username,
-      hasAvatar: !!newUser.avatar_path,
+      hasAvatar: !!newUser.avatar_url,
     });
     setUser(newUser);
     localStorage.setItem("user", JSON.stringify(newUser));

--- a/frontend/src/pages/AdminAccount.tsx
+++ b/frontend/src/pages/AdminAccount.tsx
@@ -64,12 +64,12 @@ const AdminAccount: React.FC = () => {
         await UserService.deleteAvatar(activeAvatar.id);
         alert("アバター画像を削除しました");
 
-        // ユーザー情報を更新（avatar_pathをクリア）
+        // ユーザー情報を更新（avatar_urlをクリア）
         if (user) {
           console.log(
             "🔵 AdminAccount.handleAvatarDelete: Updating user via AuthContext.updateUser",
           );
-          const updatedUser = { ...user, avatar_path: null };
+          const updatedUser = { ...user, avatar_url: null };
           updateUser(updatedUser);
           console.log(
             "✅ AdminAccount.handleAvatarDelete: User updated successfully without API calls",

--- a/frontend/src/pages/UserMyPage.tsx
+++ b/frontend/src/pages/UserMyPage.tsx
@@ -70,12 +70,12 @@ const UserMyPage: React.FC = () => {
         await UserService.deleteAvatar(activeAvatar.id);
         alert("アバター画像を削除しました");
 
-        // ユーザー情報を更新（avatar_pathをクリア）
+        // ユーザー情報を更新（avatar_urlをクリア）
         if (user) {
           console.log(
             "🔵 UserMyPage.handleAvatarDelete: Updating user via AuthContext.updateUser",
           );
-          const updatedUser = { ...user, avatar_path: null };
+          const updatedUser = { ...user, avatar_url: null };
           updateUser(updatedUser);
           console.log(
             "✅ UserMyPage.handleAvatarDelete: User updated successfully without API calls",


### PR DESCRIPTION
## Summary
マイページとアバター関連コンポーネントで発見された複数の不具合を修正しました。
主に`avatar_path`（古い形式）と`avatar_url`（正しいBASE64データURL）の使い分けに関する問題を解決しています。

## 主な修正内容

### 🔧 重要な機能修正
1. **UserMyPage.tsx**: アバター削除時に`avatar_path`ではなく`avatar_url`をクリアするように修正
2. **AdminAccount.tsx**: 同様のアバター削除処理を修正
3. **UserProfileModal.tsx**: 
   - アバター表示で間違った参照（`avatar_path`）を`avatar_url`に修正
   - 間違ったURL構築（`http://localhost:8000${user.avatar_path}`）を正しい`user.avatar_url`に修正
   - AvatarUploadコンポーネントに正しい値を渡すように修正
4. **AdminProfileView.tsx**: AvatarUploadに`avatar_url`を渡すように修正

### 📝 ログ出力の一貫性修正
5. **AuthContext.tsx**: デバッグログでも`avatar_url`を参照するように統一

## 問題の根本原因
- `avatar_path`: データベースに保存された古い形式のパス文字列（例: "avatar_file_2"）
- `avatar_url`: Laravelのアクセサーで動的生成される正しいBASE64画像データURL
- いくつかのコンポーネントで古い`avatar_path`への参照が残っており、アバター表示や削除処理に影響していた

## Test plan
- [x] ESLintチェック実行（エラーなし）
- [x] フロントエンドアクセス確認（正常）
- [x] アバター表示機能の修正確認
- [x] アバター削除機能の修正確認
- [x] 管理者画面でのアバター機能確認

## 影響範囲
- マイページのアバター機能
- 管理者アカウントページのアバター機能  
- ユーザープロフィールモーダルのアバター表示
- アバター削除後の状態更新

この修正により、すべてのアバター関連機能が一貫して正しい`avatar_url`を使用するようになります。

🤖 Generated with [Claude Code](https://claude.ai/code)