### PR TITLE
fix: 記事購入時の支払いステータス不整合による不具合修正

### DIFF
--- a/backend/app/Http/Controllers/PaymentController.php
+++ b/backend/app/Http/Controllers/PaymentController.php
@@ -52,7 +52,7 @@ class PaymentController extends Controller
         // 既に購入済みかチェック
         $existingPayment = Payment::where('user_id', auth()->id())
             ->where('article_id', $article->id)
-            ->where('status', 'success')
+            ->where('status', 'completed')
             ->first();
 
         if ($existingPayment) {
@@ -86,7 +86,7 @@ class PaymentController extends Controller
                 'user_id' => auth()->id(),
                 'article_id' => $article->id,
                 'amount' => $article->price,
-                'status' => $cardResult === 'success' ? 'success' : 'failed',
+                'status' => $cardResult === 'success' ? 'completed' : 'failed',
                 'transaction_id' => $transactionId,
                 'paid_at' => $cardResult === 'success' ? now() : null,
             ]);

--- a/frontend/src/api/payment.ts
+++ b/frontend/src/api/payment.ts
@@ -14,7 +14,7 @@ export interface PaymentResponse {
   id: number;
   article_id: number;
   amount: number;
-  status: "success" | "failed" | "pending";
+  status: "completed" | "failed" | "pending";
   transaction_id: string;
   paid_at: string;
 }
@@ -72,7 +72,7 @@ export const paymentApi = {
 
       const purchasedArticle = response.data.data.find(
         (payment) =>
-          payment.article_id === articleId && payment.status === "success",
+          payment.article_id === articleId && payment.status === "completed",
       );
 
       return !!purchasedArticle;


### PR DESCRIPTION
## Summary
記事購入時に発生していた支払いステータスの不整合を修正しました。

## 問題
データベースに保存されている支払いステータスが`completed`なのに、フロントエンドとバックエンドで`success`として処理されていました。

### 発生していた不具合
- **重複購入が可能** - 既存購入チェックが機能しない
- **購入済み状態が認識されない** - 購入後に正しく購入済みと認識されない
- **売上管理に反映されない** - ステータス不一致で集計から漏れる

## 修正内容

### バックエンド (PaymentController.php)
- 既存購入チェック: `status = 'success'` → `status = 'completed'`
- 新規支払い作成: `status = 'success'` → `status = 'completed'`

### フロントエンド (payment.ts)
- 購入状況確認: `status === 'success'` → `status === 'completed'`
- PaymentResponse型定義: `"success"` → `"completed"`

## Test plan
- [x] リンター・フォーマッター実行確認
- [x] 支払いステータスの整合性確認
- [x] 既存購入チェック動作確認
- [x] 購入済み状態認識確認

## 影響範囲
- 記事購入機能
- 購入履歴表示
- 売上管理機能

🤖 Generated with [Claude Code](https://claude.ai/code)